### PR TITLE
Fix m0_client address probing for MPI and Makefile variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ sagercf:
 #	$(APPASSIGN) ganesan $(C0RM) 172.18.1.${c} > $(RCDIR)/$(C0RM)rc/client-${c}
 #	$(APPASSIGN) ganesan $(C0CP) 172.18.1.${c} > $(RCDIR)/$(ISC_REG)rc/client-${c}
 #	$(APPASSIGN) ganesan $(C0CT) 172.18.1.${c} > $(RCDIR)/$(ISC_INVK)rc/client-${c}
-	./scripts/motraddr.sh > out-$(HOSTNAME).txt
+	HOSTNAME=$(NODE) ./scripts/motraddr.sh > out-$(HOSTNAME).txt
 	@echo "#####"
 	cat ./out-$(HOSTNAME).txt
 	@echo "#####"
@@ -233,7 +233,7 @@ mpi-clean:
 
 mpi-sagercf:
 	mkdir -p $(RCDIR)/${MPIX}rc
-	./scripts/motraddr.sh 2 > out-$(HOSTNAME).txt
+	HOSTNAME=$(NODE) ./scripts/motraddr.sh 2 > out-$(HOSTNAME).txt
 	@echo "#####"
 	cat ./out-$(HOSTNAME).txt
 	@echo "#####"


### PR DESCRIPTION
This patch fixes the incorrect hostname used in the Mero config file generation script. The `HOSTNAME` variable is not necessarily the hostname (sage-login) of the compute node. The generation script now prints all the `m0_client` addresses for a node instead of a hard-coded number of addresses.