### PR TITLE
Change in Alex workflow

### DIFF
--- a/.github/workflows/alex_reviewdog.yml
+++ b/.github/workflows/alex_reviewdog.yml
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+
+# Configuration for alex - https://github.com/get-alex/alex
+
+name: CORTX inclusive words scan
+on:
+  # Trigger the workflow on pull request labeled as cla-signed
+  # and synchronize for the main branch
+  pull_request:
+    types: [ opened, synchronize ]
+    branches:
+      - main
+  # Trigger the workflow on demand
+  workflow_dispatch:
+jobs:
+  # Let's start the alex to scan
+  alex:
+    name: Alex report
+    #if: ${{ github.event.label.name == 'alex' || github.event.action == 'synchronize' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-alex@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          filter_mode: added
+          reporter: github-pr-review
+          fail_on_error: true
+          level: warning
+          


### PR DESCRIPTION
Problem Statement:
Triggering the Alex based on cla-signed is not appropriate because the label is not assigned for all the PRs .

Solution:
The Alex event will trigger whenever the PR is opened. Kindly refer the below document for more information about the tool Alex.

Signed-off-by: Venkatesh K <venkatesh.k@seagate.com>

Kindly refer Alex documentation
https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/584778705/Alex+Workflow