### PR TITLE
CORTX-28529 : Inconsiderate words reported by Alex in cortx-motr-apps repo

### DIFF
--- a/scripts/sage-user-application-assignment
+++ b/scripts/sage-user-application-assignment
@@ -115,7 +115,7 @@ def regenerate(tier_name, tier_file, client, no_ssh):
         applications = sorted([{'endpoint': h[0]['r_endpoint'],
                                 'process_fid': h[0]['r_fid']}
                                for h in clients[ip]
-                               if h[1]['cprType'] == 'clovis-app'],
+                               if h[1]['cprType'] == 'motr-app'],
                               key=lambda k: k['endpoint'])
         tier_data[ip] = {'profile': profile,
                          'ha': ha_endpoint,


### PR DESCRIPTION
CORTX-28529 : Inconsiderate words reported by Alex            
                         in cortx-motr-apps repo

As all the clovis-apps are renamed as either
motr-apps or motr-client-apps, here "clovis-app"
is replaced with "motr-app".

Signed-off-by: Bhargav Dekivadiya <bhargav.dekivadiya@seagate.com>