### PR TITLE
CORTX-30785: Fixing the Alex bug

### DIFF
--- a/.github/workflows/alex_reviewdog.yml
+++ b/.github/workflows/alex_reviewdog.yml
@@ -35,11 +35,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: Seagate/action-alex@v1
+      
+      - name: "Enable the permissions"
+        run: |
+          sudo chown -R root:root $GITHUB_WORKSPACE
+      
+      - uses: seagate/action-alex@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           filter_mode: added
           reporter: github-pr-review
           fail_on_error: true
           level: warning
-          


### PR DESCRIPTION
Problem: 
Alex's Github Action is fails with an error "reviewdog: PullRequest needs 'git' command: failed to run 'git rev-parse --show-prefix'" 

Solution: 
Changed the permissions of the directory where the target repository is checkeout in the workflow of GitHub Actions.

Signed-off-by: Venkatesh K <venkatesh.k@seagate.com>